### PR TITLE
chore: harden repository security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,21 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
+
+  - package-ecosystem: gomod
+    directory: /services/sidecar-go
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: bundler
+    directory: /apps/mobile
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: gradle
+    directory: /apps/mobile/android
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294
+        with:
+          fail-on-severity: high

--- a/docs/release/release-playbook.md
+++ b/docs/release/release-playbook.md
@@ -193,16 +193,18 @@ start an upload in that state and never moves, deletes, or recreates the tag.
 3. Optionally dispatch `OSS Draft Release` manually. Confirm all reusable jobs
    pass, the four intermediate artifact groups exist, and no release is
    created.
-4. Create and push one stable `vX.Y.Z` tag only after the target commit and
-   repository checks are approved.
+4. After the target commit and repository checks are approved, a repository
+   admin creates and pushes one stable `vX.Y.Z` tag. The release tag ruleset
+   blocks other roles from creating, updating, or deleting matching tags.
 5. Do not publish the draft while the tag workflow or any rerun is in progress.
 6. After the run completes, confirm the draft contains only the six versioned
    files and `SHA256SUMS`.
 7. Download the files, verify their checksums, and record platform smoke-test
    results before any separate publication decision.
 8. Publish only after the completed run, asset list, and checksums have been
-   reviewed. Consider enabling GitHub immutable releases as an additional
-   repository-level protection for published releases.
+   reviewed. GitHub immutable releases protect the published tag and assets
+   from later modification or deletion; drafts remain editable until they are
+   published.
 
 For a failed tag run, keep the tag fixed and address only transient workflow or
 packaging failures that do not require source changes. Rerun the workflow to

--- a/scripts/release/__tests__/workflow-contracts.test.mjs
+++ b/scripts/release/__tests__/workflow-contracts.test.mjs
@@ -4,7 +4,7 @@ import test from 'node:test';
 import { parse } from 'yaml';
 
 const repoRoot = new URL('../../..', import.meta.url);
-const ACTION_SHA = /^[\w.-]+\/[\w.-]+@[0-9a-f]{40}$/;
+const ACTION_SHA = /^[\w.-]+(?:\/[\w.-]+)+@[0-9a-f]{40}$/;
 const NODE_24_ACTIONS = new Map([
   ['actions/checkout', '9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0'],
   ['actions/setup-go', '924ae3a1cded613372ab5595356fb5720e22ba16'],
@@ -12,7 +12,10 @@ const NODE_24_ACTIONS = new Map([
   ['actions/setup-node', '820762786026740c76f36085b0efc47a31fe5020'],
   ['actions/upload-artifact', '043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'],
   ['actions/download-artifact', '70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3'],
+  ['actions/dependency-review-action', 'a1d282b36b6f3519aa1f3fc636f609c47dddb294'],
   ['dorny/paths-filter', '7b450fff21473bca461d4b92ce414b9d0420d706'],
+  ['github/codeql-action/init', '99df26d4f13ea111d4ec1a7dddef6063f76b97e9'],
+  ['github/codeql-action/analyze', '99df26d4f13ea111d4ec1a7dddef6063f76b97e9'],
   ['pnpm/action-setup', '0ebf47130e4866e96fce0953f49152a61190b271'],
 ]);
 
@@ -60,6 +63,8 @@ test('workflow JavaScript actions use reviewed Node 24 releases', () => {
     '.github/workflows/oss-release-gate.yml',
     '.github/workflows/native-builds.yml',
     '.github/workflows/release.yml',
+    '.github/workflows/codeql.yml',
+    '.github/workflows/dependency-review.yml',
   ]) {
     for (const step of allWorkflowSteps(workflow(path))) {
       const [action] = String(step.uses ?? '').split('@');
@@ -161,18 +166,60 @@ test('repository CI workflow runs TypeScript quality and Go tests', () => {
 test('Dependabot proposes reviewed monthly dependency updates', () => {
   const config = workflow('.github/dependabot.yml');
   const updates = config.updates ?? [];
-  const pnpm = updates.find(update => update['package-ecosystem'] === 'npm');
-  const actions = updates.find(
-    update => update['package-ecosystem'] === 'github-actions',
-  );
+  const expected = new Map([
+    ['npm', '/'],
+    ['github-actions', '/'],
+    ['gomod', '/services/sidecar-go'],
+    ['bundler', '/apps/mobile'],
+    ['gradle', '/apps/mobile/android'],
+  ]);
 
   assert.equal(config.version, 2);
-  for (const update of [pnpm, actions]) {
+  assert.equal(updates.length, expected.size);
+  for (const [ecosystem, directory] of expected) {
+    const update = updates.find(
+      candidate => candidate['package-ecosystem'] === ecosystem,
+    );
     assert.ok(update);
-    assert.equal(update.directory, '/');
+    assert.equal(update.directory, directory);
     assert.equal(update.schedule?.interval, 'monthly');
     assert.equal(update['open-pull-requests-limit'], 5);
   }
+});
+
+test('security workflows are least-privileged and block risky dependencies', () => {
+  const codeql = workflow('.github/workflows/codeql.yml');
+  const analyze = codeql.jobs?.analyze;
+  const dependencyReview = workflow('.github/workflows/dependency-review.yml');
+  const review = dependencyReview.jobs?.['dependency-review'];
+
+  assert.equal(codeql.name, 'CodeQL');
+  assertCommonTriggers(codeql);
+  assert.deepEqual(codeql.permissions, { contents: 'read' });
+  assert.deepEqual(analyze?.permissions, {
+    contents: 'read',
+    packages: 'read',
+    'security-events': 'write',
+  });
+  assert.deepEqual(analyze?.strategy?.matrix?.include, [
+    { language: 'javascript-typescript', 'build-mode': 'none' },
+    { language: 'go', 'build-mode': 'autobuild' },
+  ]);
+  assertActionsPinned(analyze?.steps ?? []);
+
+  assert.equal(dependencyReview.name, 'Dependency Review');
+  assert.ok(dependencyReview.on?.pull_request !== undefined);
+  assert.deepEqual(dependencyReview.permissions, { contents: 'read' });
+  assert.equal(review?.name, 'Dependency Review');
+  assert.equal(review?.['runs-on'], 'ubuntu-24.04');
+  assert.equal(review?.['timeout-minutes'], 10);
+  assert.equal(
+    findStep(review?.steps ?? [], 'Review dependency changes').with?.[
+      'fail-on-severity'
+    ],
+    'high',
+  );
+  assertActionsPinned(review?.steps ?? []);
 });
 
 test('native build workflow is path-aware, unsigned, and platform-bounded', () => {


### PR DESCRIPTION
## Summary

- Add CodeQL analysis for JavaScript/TypeScript and Go with SHA-pinned actions.
- Add dependency review that rejects newly introduced high or critical vulnerabilities.
- Extend monthly Dependabot coverage to Go modules, Bundler, and Gradle.
- Document protected release tags and immutable published releases.
- Add workflow contract coverage for the new security configuration.

The related repository settings are already enabled separately: private vulnerability reporting, Dependabot security updates, secret scanning, push protection, the `v*` release tag ruleset, and immutable releases.

## Impact Scope

GitHub workflows, dependency maintenance configuration, release operations documentation, and workflow contract tests only. No product runtime, native application, sidecar, protocol, persistence, or sync behavior changes.

## Validation

- `node --test scripts/release/__tests__/workflow-contracts.test.mjs`
- `pnpm format:check`
- `pnpm gate:release`
- GitHub API readback for all repository settings and ruleset ID 19033363

## Visual Evidence

Not applicable.

## Contamination Review

No DTOs, shared state, persistence, queue semantics, sync state machine, permission/account gates, history statistics, signing, upload, or non-OSS paths were changed.

## Checklist

- [x] I reviewed the complete diff.
- [x] I added or updated focused tests.
- [x] I ran the applicable validation commands.
- [x] I updated release documentation.
- [x] I confirmed no secrets or generated artifacts were added.