### PR TITLE
fix: use APK signature v2 for MIUI compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,12 +108,19 @@ jobs:
           APKSIGNER="$ANDROID_HOME/build-tools/36.0.0/apksigner"
 
           "$APKSIGNER" sign \
+            --v1-signing-enabled false \
+            --v2-signing-enabled true \
+            --v3-signing-enabled false \
+            --v4-signing-enabled false \
             --ks "$ANDROID_RELEASE_KEYSTORE_PATH" \
             --ks-key-alias "$ANDROID_RELEASE_KEY_ALIAS" \
             --ks-pass env:ANDROID_RELEASE_STORE_PASSWORD \
             --key-pass env:ANDROID_RELEASE_KEY_PASSWORD \
             "$APK_PATH"
-          "$APKSIGNER" verify --verbose --print-certs "$APK_PATH"
+          APK_VERIFY_OUTPUT="$("$APKSIGNER" verify --verbose --print-certs "$APK_PATH")"
+          printf '%s\n' "$APK_VERIFY_OUTPUT"
+          grep -Fq 'Verified using v2 scheme (APK Signature Scheme v2): true' <<< "$APK_VERIFY_OUTPUT"
+          grep -Fq 'Verified using v3 scheme (APK Signature Scheme v3): false' <<< "$APK_VERIFY_OUTPUT"
 
           jarsigner \
             -keystore "$ANDROID_RELEASE_KEYSTORE_PATH" \

--- a/docs/release/release-playbook.md
+++ b/docs/release/release-playbook.md
@@ -239,6 +239,13 @@ jarsigner -verify -verbose -certs \
   LynavoDriveDemo-<version>-android-arm64-x86_64.aab
 ```
 
+The APK must report v2 signing as `true` and v1, v3, and v4 signing as
+`false`. This explicit v2-only profile preserves compatibility with MIUI 14
+package installers that reject an otherwise valid v3-only APK during package
+metadata parsing. Do not remove the signing-scheme flags from the workflow and
+rely on `apksigner` defaults: for an APK with `minSdkVersion` 29, Build Tools 36
+selects v3-only signing by default.
+
 An existing draft may be updated idempotently. A rerun for the same tag
 preserves its generated notes and replaces the seven allowlisted assets above
 with the newly rebuilt set. Immediately before uploading, the workflow checks

--- a/scripts/release/__tests__/workflow-contracts.test.mjs
+++ b/scripts/release/__tests__/workflow-contracts.test.mjs
@@ -656,9 +656,15 @@ test('draft release workflow signs Android assets only for stable tags', () => {
     'ANDROID_RELEASE_STORE_PASSWORD',
   ]);
   assert.match(sign.run, /"\$APKSIGNER" sign/);
+  assert.match(sign.run, /--v1-signing-enabled false/);
+  assert.match(sign.run, /--v2-signing-enabled true/);
+  assert.match(sign.run, /--v3-signing-enabled false/);
+  assert.match(sign.run, /--v4-signing-enabled false/);
   assert.match(sign.run, /--ks-pass env:ANDROID_RELEASE_STORE_PASSWORD/);
   assert.match(sign.run, /--key-pass env:ANDROID_RELEASE_KEY_PASSWORD/);
   assert.match(sign.run, /"\$APKSIGNER" verify --verbose --print-certs/);
+  assert.match(sign.run, /Verified using v2 scheme .*: true/);
+  assert.match(sign.run, /Verified using v3 scheme .*: false/);
   assert.match(sign.run, /jarsigner/);
   assert.match(sign.run, /-verify/);
   assert.doesNotMatch(sign.run, /jarsigner -verify -strict/);


### PR DESCRIPTION
## Summary

- sign stable-tag Android APKs with an explicit v2-only scheme
- fail the signing job unless verification reports v2=true and v3=false
- document the MIUI 14 compatibility requirement and protect it with a workflow contract test

## Impact

Only the stable-tag Android APK signing step changes. APK package identity, release certificate, unsigned native builds, AAB signing, mobile runtime, desktop builds, shared contracts, persistence, queue semantics, and sync state are unchanged.

## Evidence

The previous Build Tools 36 default produced a valid v3-only APK for minSdk 29. That APK installed on Android 13 PEGM10 but MIUI 14 returned PackageInfo is null. A comparison APK that installs on the same Xiaomi device used v2-only signing. The same Lynavo APK re-signed v2-only was then confirmed installable by the affected user.

## Validation

- `pnpm test:release` (144 passed)
- workflow YAML parsed with the repository YAML dependency
- changed files pass Prettier
- `git diff --check`
- real signed APK verification reports v1=false, v2=true, v3=false, v4=false
- v2 APK installed successfully on PEGM10 and the affected Xiaomi 13 / MIUI 14 device

## Contamination check

No signing material or packaged artifacts are committed. No DTO/protocol, persistence, queue, state-machine, permission, account-service, or history behavior changed.