### PR TITLE
[bug] Fix Android auto-upload time picker crash

### DIFF
--- a/apps/mobile/src/screens/AutoUploadSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AutoUploadSettingsScreen.tsx
@@ -45,6 +45,7 @@ import {
 } from '../services/SyncEngineModule';
 
 type AutoUploadRange = 'all' | 'now' | 'custom';
+type AndroidPickerMode = 'date' | 'time';
 
 const BLUE = '#1677D2';
 const DARK = '#17191C';
@@ -198,6 +199,8 @@ export function AutoUploadSettingsScreen() {
     useState<AutoUploadTimeRangeMode>('all');
   const [rangeEdited, setRangeEdited] = useState(false);
   const [showDatePicker, setShowDatePicker] = useState(false);
+  const [androidPickerMode, setAndroidPickerMode] =
+    useState<AndroidPickerMode>('date');
   const [customDate, setCustomDate] = useState<Date>(new Date());
   const [tempDate, setTempDate] = useState<Date>(new Date());
   const [configLoading, setConfigLoading] = useState(true);
@@ -345,6 +348,7 @@ export function AutoUploadSettingsScreen() {
     setUploadRange(range);
     if (range === 'custom') {
       setTempDate(customDate);
+      setAndroidPickerMode('date');
       setShowDatePicker(true);
       return;
     }
@@ -358,10 +362,33 @@ export function AutoUploadSettingsScreen() {
     selectedDate?: Date,
   ) => {
     if (Platform.OS === 'android') {
+      if (event.type !== 'set' || !selectedDate) {
+        setShowDatePicker(false);
+        return;
+      }
+      if (androidPickerMode === 'date') {
+        const nextDate = new Date(tempDate);
+        nextDate.setFullYear(
+          selectedDate.getFullYear(),
+          selectedDate.getMonth(),
+          selectedDate.getDate(),
+        );
+        setTempDate(nextDate);
+        setAndroidPickerMode('time');
+        return;
+      }
+      const nextDate = new Date(tempDate);
+      nextDate.setHours(
+        selectedDate.getHours(),
+        selectedDate.getMinutes(),
+        0,
+        0,
+      );
+      setCustomDate(nextDate);
+      setTempDate(nextDate);
       setShowDatePicker(false);
-      if (event.type === 'set' && selectedDate) {
-        setCustomDate(selectedDate);
-        setTempDate(selectedDate);
+      if (autoUploadEnabled) {
+        void persistAlbumAutoUploadConfig('custom', nextDate, true);
       }
     } else if (selectedDate) {
       setTempDate(selectedDate);
@@ -715,8 +742,8 @@ export function AutoUploadSettingsScreen() {
 
       {showDatePicker && Platform.OS === 'android' && (
         <DateTimePicker
-          value={customDate}
-          mode="datetime"
+          value={tempDate}
+          mode={androidPickerMode}
           display="default"
           onChange={handleDateChange}
         />

--- a/apps/mobile/src/screens/__tests__/AutoUploadSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoUploadSettingsScreen.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
-import { Alert, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import {
+  Alert,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+} from 'react-native';
 import {
   disableAutoUpload,
   enableAutoUpload,
@@ -12,6 +18,7 @@ import {
 const mockGoBack = jest.fn();
 const mockDispatch = jest.fn();
 const mockCanGoBack = jest.fn();
+const originalPlatformOS = Platform.OS;
 
 jest.mock('@react-navigation/native', () => ({
   CommonActions: {
@@ -167,6 +174,10 @@ describe('AutoUploadSettingsScreen', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: originalPlatformOS,
+    });
     jest.restoreAllMocks();
   });
 
@@ -402,6 +413,106 @@ describe('AutoUploadSettingsScreen', () => {
         'DateTimePicker' as unknown as React.ComponentType,
       ),
     ).toHaveLength(1);
+  });
+
+  it('starts Android custom time selection with the supported date picker mode', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: 'android',
+    });
+    const tree = await renderScreen();
+
+    ReactTestRenderer.act(() => {
+      tree.root
+        .findByProps({ testID: 'auto-upload-range-custom' })
+        .props.onPress();
+    });
+
+    const picker = tree.root.findByType(
+      'DateTimePicker' as unknown as React.ComponentType,
+    );
+    expect(picker.props.mode).toBe('date');
+  });
+
+  it('continues Android custom time selection with a time picker after the date is set', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: 'android',
+    });
+    const tree = await renderScreen();
+
+    ReactTestRenderer.act(() => {
+      tree.root
+        .findByProps({ testID: 'auto-upload-range-custom' })
+        .props.onPress();
+    });
+    ReactTestRenderer.act(() => {
+      tree.root
+        .findByType('DateTimePicker' as unknown as React.ComponentType)
+        .props.onChange({ type: 'set' }, new Date('2026-07-20T03:04:00.000Z'));
+    });
+
+    const picker = tree.root.findByType(
+      'DateTimePicker' as unknown as React.ComponentType,
+    );
+    expect(picker.props.mode).toBe('time');
+  });
+
+  it('persists the combined Android custom date and time selection', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: 'android',
+    });
+    const initialDate = new Date('2026-06-16T03:04:05.000Z');
+    const selectedDate = new Date(2026, 6, 20, 0, 0, 0, 0);
+    const selectedTime = new Date(2026, 0, 1, 14, 45, 0, 0);
+    const expectedDate = new Date(initialDate);
+    expectedDate.setFullYear(
+      selectedDate.getFullYear(),
+      selectedDate.getMonth(),
+      selectedDate.getDate(),
+    );
+    expectedDate.setHours(
+      selectedTime.getHours(),
+      selectedTime.getMinutes(),
+      0,
+      0,
+    );
+    mockedGetAutoUploadConfig.mockResolvedValueOnce({
+      enabled: true,
+      timeRangeMode: 'custom',
+      customTimeFrom: initialDate.toISOString(),
+      state: 'active',
+    });
+    const tree = await renderScreen();
+
+    ReactTestRenderer.act(() => {
+      tree.root
+        .findByProps({ testID: 'auto-upload-range-custom' })
+        .props.onPress();
+    });
+    ReactTestRenderer.act(() => {
+      tree.root
+        .findByType('DateTimePicker' as unknown as React.ComponentType)
+        .props.onChange({ type: 'set' }, selectedDate);
+    });
+    await ReactTestRenderer.act(async () => {
+      tree.root
+        .findByType('DateTimePicker' as unknown as React.ComponentType)
+        .props.onChange({ type: 'set' }, selectedTime);
+      await Promise.resolve();
+    });
+
+    expect(
+      tree.root.findAllByType(
+        'DateTimePicker' as unknown as React.ComponentType,
+      ),
+    ).toHaveLength(0);
+    expect(mockedSaveAutoUploadConfig).toHaveBeenCalledWith({
+      enabled: true,
+      timeRangeMode: 'custom',
+      customTimeFrom: expectedDate.toISOString(),
+    });
   });
 
   it('saves range changes immediately while auto upload is enabled', async () => {


### PR DESCRIPTION
## Summary
- replace the unsupported Android `datetime` picker mode with a supported date-then-time flow
- preserve the existing time while choosing a date, then merge the chosen time before saving
- cover Android picker modes and persisted combined timestamps with regression tests

## Root cause
`@react-native-community/datetimepicker` supports `date` and `time` on Android, but the screen passed `mode="datetime"`. The native picker opened through its date fallback, then attempted to dismiss the undefined `datetime` picker and crashed with `Cannot read property "dismiss" of undefined`.

## Validation
- `pnpm --filter @lynavo-drive/mobile exec jest --no-watchman --runInBand src/screens/__tests__/AutoUploadSettingsScreen.test.tsx` (18 passed)
- `pnpm --filter @lynavo-drive/mobile exec tsc --noEmit`
- `pnpm exec prettier --check apps/mobile/src/screens/AutoUploadSettingsScreen.tsx apps/mobile/src/screens/__tests__/AutoUploadSettingsScreen.test.tsx`
- `ANDROID_HOME=/Users/x/Library/Android/sdk pnpm --filter @lynavo-drive/mobile build:android`
- full mobile suite: 438 passed; one unrelated `AlbumWorkbenchScreen` test timed out under suite load, then passed 15/15 when rerun alone

## Device verification
The crash was reproduced on the connected Android 13 device. The fixed Debug APK was not installed over the existing release-signed app because the signatures differ and replacing it would require clearing the app data.