### PR TITLE
[bug] Fix Android LAN download save reporting

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitives.kt
+++ b/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitives.kt
@@ -114,6 +114,11 @@ data class AndroidSharedFilesRouteDecision(
   val port: Int,
 )
 
+data class AndroidPublicDownloadResult(
+  val localPath: String?,
+  val savedLocation: String,
+)
+
 data class AndroidPersonalAccessSignature(
   val signature: String,
   val timestamp: String,
@@ -174,6 +179,15 @@ data class AndroidForegroundLanRuntimeDecision(
 )
 
 object AndroidSyncPrimitives {
+  fun publicDownloadResult(
+    exposeContentUri: Boolean,
+    contentUri: String,
+    savedLocation: String,
+  ): AndroidPublicDownloadResult = AndroidPublicDownloadResult(
+    localPath = contentUri.takeIf { exposeContentUri },
+    savedLocation = savedLocation,
+  )
+
   fun mergeWakeCapability(
     newWake: AndroidWakeCapability?,
     existingWake: AndroidWakeCapability?,

--- a/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/NativeSyncEngineModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/NativeSyncEngineModule.kt
@@ -3165,17 +3165,21 @@ class NativeSyncEngineModule(
       tempFile.delete() // Stored in public Downloads; remove the private temporary backup
       recordNativeLog(
         "SharedFiles",
-        "persistHttpDownload saved_to_downloads filename=$safeFilename saved_location=$savedLocation local_path=$uri expose_uri=true",
+        "persistHttpDownload saved_to_downloads filename=$safeFilename saved_location=$savedLocation local_path=$uri expose_uri=$exposeDownloadsUri",
+      )
+      val result = AndroidSyncPrimitives.publicDownloadResult(
+        exposeContentUri = exposeDownloadsUri,
+        contentUri = uri.toString(),
+        savedLocation = savedLocation,
       )
       return Arguments.createMap().apply {
         putBoolean("savedToPhotos", false)
-        if (exposeDownloadsUri) {
-          putString("localPath", uri.toString())
-          putString("savedLocation", savedLocation)
+        if (result.localPath != null) {
+          putString("localPath", result.localPath)
         } else {
           putNull("localPath")
-          putNull("savedLocation")
         }
+        putString("savedLocation", result.savedLocation)
       }
     }
 

--- a/apps/mobile/android/app/src/test/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitivesTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitivesTest.kt
@@ -10,6 +10,18 @@ import org.junit.Test
 
 class AndroidSyncPrimitivesTest {
   @Test
+  fun publicDownloadResultKeepsSavedLocationWhenContentUriIsHidden() {
+    val result = AndroidSyncPrimitives.publicDownloadResult(
+      exposeContentUri = false,
+      contentUri = "content://downloads/public_downloads/42",
+      savedLocation = "Download/Lynavo Drive",
+    )
+
+    assertNull(result.localPath)
+    assertEquals("Download/Lynavo Drive", result.savedLocation)
+  }
+
+  @Test
   fun sharedFilesRouteUsesDirectLanHost() {
     val route = AndroidSyncPrimitives.decideSharedFilesRoute(
       directHost = " 172.20.10.3 ",


### PR DESCRIPTION
## Summary

- Preserve `savedLocation` when Android 10+ stores LAN-shared regular files in `Downloads/Lynavo Drive`.
- Keep the existing policy that hides the `content://` URI for directory downloads.
- Add a regression test for the hidden-URI result.

## Root cause

`downloadSharedFileFromRoute()` intentionally passed `exposeDownloadsUri = false`. The native MediaStore write succeeded, but the result cleared both `localPath` and `savedLocation`, so JavaScript incorrectly reported the download as unsupported.

## Validation

- `./gradlew testDebugUnitTest --tests com.lynavo.drive.mobile.demo.sync.AndroidSyncPrimitivesTest.publicDownloadResultKeepsSavedLocationWhenContentUriIsHidden`
- `pnpm --filter @lynavo-drive/mobile exec jest --runInBand --silent src/services/__tests__/desktop-local-service.test.ts src/screens/__tests__/SharedFilesDownloadGate.test.tsx` (2 suites, 95 tests)
- `pnpm --filter @lynavo-drive/mobile exec tsc --noEmit`
- `git diff --check`

The Android unit test initially exposed stale autolinking output after the Async Storage dependency upgrade; generated build caches were refreshed and the test then passed.