### PR TITLE
[bug] make auto-upload use all content only

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidMediaStoreRepository.kt
+++ b/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidMediaStoreRepository.kt
@@ -28,8 +28,12 @@ data class AndroidMediaAsset(
 )
 
 class AndroidMediaStoreRepository(private val context: Context) {
-  fun scanAssets(clientId: String): List<AndroidUploadItem> =
-    queryAssets(mediaFilter = "all", collectionId = null)
+  fun scanAssets(clientId: String, addedAfterEpochSeconds: Long? = null): List<AndroidUploadItem> =
+    queryAssets(
+      mediaFilter = "all",
+      collectionId = null,
+      addedAfterEpochSeconds = addedAfterEpochSeconds,
+    )
       .map { asset -> asset.toUploadItem(clientId = clientId, source = "auto", batchId = null) }
 
   fun findAssetsByIds(assetLocalIds: List<String>, clientId: String, source: String, batchId: String): List<AndroidUploadItem> {
@@ -160,23 +164,35 @@ class AndroidMediaStoreRepository(private val context: Context) {
     return null
   }
 
-  private fun queryAssets(mediaFilter: String, collectionId: String?): List<AndroidMediaAsset> {
+  private fun queryAssets(
+    mediaFilter: String,
+    collectionId: String?,
+    addedAfterEpochSeconds: Long? = null,
+  ): List<AndroidMediaAsset> {
     val collections = when (mediaFilter) {
       "photos", "image", "images" -> listOf(MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
       "videos", "video" -> listOf(MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
       else -> listOf(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
     }
-    return collections.flatMap { uri -> queryCollection(uri, collectionId) }
+    return collections.flatMap { uri -> queryCollection(uri, collectionId, addedAfterEpochSeconds) }
       .sortedByDescending { it.createdAt }
   }
 
-  private fun queryCollection(collectionUri: Uri, collectionId: String?): List<AndroidMediaAsset> {
+  private fun queryCollection(
+    collectionUri: Uri,
+    collectionId: String?,
+    addedAfterEpochSeconds: Long?,
+  ): List<AndroidMediaAsset> {
     val projection = assetProjection()
     val selectionParts = mutableListOf<String>()
     val selectionArgs = mutableListOf<String>()
     if (!collectionId.isNullOrBlank()) {
       selectionParts.add("${MediaStore.MediaColumns.BUCKET_ID}=?")
       selectionArgs.add(collectionId)
+    }
+    if (addedAfterEpochSeconds != null) {
+      selectionParts.add("${MediaStore.MediaColumns.DATE_ADDED}>=?")
+      selectionArgs.add(addedAfterEpochSeconds.toString())
     }
     val selection = selectionParts.takeIf { it.isNotEmpty() }?.joinToString(" AND ")
     val sortOrder = "${MediaStore.MediaColumns.DATE_ADDED} DESC"

--- a/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidMediaStoreRepository.kt
+++ b/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidMediaStoreRepository.kt
@@ -28,11 +28,11 @@ data class AndroidMediaAsset(
 )
 
 class AndroidMediaStoreRepository(private val context: Context) {
-  fun scanAssets(clientId: String, addedAfterEpochSeconds: Long? = null): List<AndroidUploadItem> =
+  fun scanAssets(clientId: String, createdAfterEpochMillis: Long? = null): List<AndroidUploadItem> =
     queryAssets(
       mediaFilter = "all",
       collectionId = null,
-      addedAfterEpochSeconds = addedAfterEpochSeconds,
+      createdAfterEpochMillis = createdAfterEpochMillis,
     )
       .map { asset -> asset.toUploadItem(clientId = clientId, source = "auto", batchId = null) }
 
@@ -167,21 +167,21 @@ class AndroidMediaStoreRepository(private val context: Context) {
   private fun queryAssets(
     mediaFilter: String,
     collectionId: String?,
-    addedAfterEpochSeconds: Long? = null,
+    createdAfterEpochMillis: Long? = null,
   ): List<AndroidMediaAsset> {
     val collections = when (mediaFilter) {
       "photos", "image", "images" -> listOf(MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
       "videos", "video" -> listOf(MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
       else -> listOf(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
     }
-    return collections.flatMap { uri -> queryCollection(uri, collectionId, addedAfterEpochSeconds) }
+    return collections.flatMap { uri -> queryCollection(uri, collectionId, createdAfterEpochMillis) }
       .sortedByDescending { it.createdAt }
   }
 
   private fun queryCollection(
     collectionUri: Uri,
     collectionId: String?,
-    addedAfterEpochSeconds: Long?,
+    createdAfterEpochMillis: Long?,
   ): List<AndroidMediaAsset> {
     val projection = assetProjection()
     val selectionParts = mutableListOf<String>()
@@ -190,9 +190,10 @@ class AndroidMediaStoreRepository(private val context: Context) {
       selectionParts.add("${MediaStore.MediaColumns.BUCKET_ID}=?")
       selectionArgs.add(collectionId)
     }
-    if (addedAfterEpochSeconds != null) {
-      selectionParts.add("${MediaStore.MediaColumns.DATE_ADDED}>=?")
-      selectionArgs.add(addedAfterEpochSeconds.toString())
+    val creationTimeFilter = AndroidSyncPrimitives.autoUploadCreationTimeFilter(createdAfterEpochMillis)
+    if (creationTimeFilter != null) {
+      selectionParts.add(creationTimeFilter.selection)
+      selectionArgs.add(creationTimeFilter.selectionArg)
     }
     val selection = selectionParts.takeIf { it.isNotEmpty() }?.joinToString(" AND ")
     val sortOrder = "${MediaStore.MediaColumns.DATE_ADDED} DESC"

--- a/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitives.kt
+++ b/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitives.kt
@@ -4,6 +4,7 @@ import java.io.BufferedOutputStream
 import java.io.File
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Locale
 import java.util.TimeZone
 import java.util.zip.ZipEntry
@@ -398,6 +399,35 @@ object AndroidSyncPrimitives {
     nextEnabled &&
       nextState == "active" &&
       (!previousEnabled || previousState != "active")
+
+  fun shouldRescanAutoUploadOnHostResume(
+    wasVisible: Boolean,
+    enabled: Boolean,
+    state: String,
+  ): Boolean = !wasVisible && enabled && state == "active"
+
+  fun autoUploadScanThresholdEpochSeconds(
+    timeRangeMode: String,
+    customTimeFrom: String?,
+    rangeStartAt: String?,
+    nowEpochMillis: Long,
+    timeZoneId: String,
+  ): Long? {
+    val thresholdMillis = when (timeRangeMode) {
+      "from_now" -> rangeStartAt?.let(::parseIsoInstantMillis)
+      "from_today" -> Calendar.getInstance(TimeZone.getTimeZone(timeZoneId)).run {
+        timeInMillis = nowEpochMillis
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+        timeInMillis
+      }
+      "custom" -> customTimeFrom?.let(::parseIsoInstantMillis)
+      else -> null
+    }
+    return thresholdMillis?.let { Math.floorDiv(it, 1_000L) }
+  }
 
   fun shouldContinueAutoUploadRound(
     roundReason: String,

--- a/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitives.kt
+++ b/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitives.kt
@@ -179,6 +179,11 @@ data class AndroidForegroundLanRuntimeDecision(
   val reason: String?,
 )
 
+data class AndroidMediaStoreTimeFilter(
+  val selection: String,
+  val selectionArg: String,
+)
+
 object AndroidSyncPrimitives {
   fun publicDownloadResult(
     exposeContentUri: Boolean,
@@ -406,7 +411,7 @@ object AndroidSyncPrimitives {
     state: String,
   ): Boolean = !wasVisible && enabled && state == "active"
 
-  fun autoUploadScanThresholdEpochSeconds(
+  fun autoUploadScanThresholdEpochMillis(
     timeRangeMode: String,
     customTimeFrom: String?,
     rangeStartAt: String?,
@@ -426,7 +431,16 @@ object AndroidSyncPrimitives {
       "custom" -> customTimeFrom?.let(::parseIsoInstantMillis)
       else -> null
     }
-    return thresholdMillis?.let { Math.floorDiv(it, 1_000L) }
+    return thresholdMillis
+  }
+
+  fun autoUploadCreationTimeFilter(
+    thresholdEpochMillis: Long?,
+  ): AndroidMediaStoreTimeFilter? = thresholdEpochMillis?.let {
+    AndroidMediaStoreTimeFilter(
+      selection = "datetaken>=?",
+      selectionArg = it.toString(),
+    )
   }
 
   fun shouldContinueAutoUploadRound(

--- a/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/NativeSyncEngineModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/NativeSyncEngineModule.kt
@@ -1891,7 +1891,7 @@ class NativeSyncEngineModule(
         config = config.copy(rangeStartAt = isoNow())
         saveAutoUploadConfig(config)
       }
-      val scanThresholdEpochSeconds = AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+      val scanThresholdEpochMillis = AndroidSyncPrimitives.autoUploadScanThresholdEpochMillis(
         timeRangeMode = config.timeRangeMode,
         customTimeFrom = config.customTimeFrom,
         rangeStartAt = config.rangeStartAt,
@@ -1901,7 +1901,7 @@ class NativeSyncEngineModule(
       recordDiagnosticsLog(
         "Sync",
         "round requested reason=$reason autoEnabled=${config.enabled} autoState=${config.state} " +
-          "timeRangeMode=${config.timeRangeMode} scanThresholdEpochSeconds=$scanThresholdEpochSeconds",
+          "timeRangeMode=${config.timeRangeMode} scanThresholdEpochMillis=$scanThresholdEpochMillis",
       )
       val roundStartRuntimeDecision = currentForegroundLanRuntimeDecision()
       if (!roundStartRuntimeDecision.canContinue) {
@@ -1922,7 +1922,7 @@ class NativeSyncEngineModule(
       val existingAssetIds = existing
         .filter { it.status in ACTIVE_UPLOAD_STATUSES }
         .mapTo(mutableSetOf()) { it.assetLocalId }
-      val discovered = mediaStoreRepository.scanAssets(clientId, scanThresholdEpochSeconds)
+      val discovered = mediaStoreRepository.scanAssets(clientId, scanThresholdEpochMillis)
         .filter { it.assetLocalId !in existingAssetIds }
       if (discovered.isNotEmpty() && config.enabled) {
         uploadStore.upsertItems(discovered.map { it.copy(source = "auto", status = "queued", updatedAt = isoNow()) })

--- a/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/NativeSyncEngineModule.kt
+++ b/apps/mobile/android/app/src/main/java/com/lynavo/drive/mobile/sync/NativeSyncEngineModule.kt
@@ -159,7 +159,18 @@ class NativeSyncEngineModule(
   }
 
   override fun onHostResume() {
+    val wasVisible = appVisible
     appVisible = true
+    val config = loadAutoUploadConfig()
+    if (
+      AndroidSyncPrimitives.shouldRescanAutoUploadOnHostResume(
+        wasVisible = wasVisible,
+        enabled = config.enabled,
+        state = config.state,
+      )
+    ) {
+      startAutoUploadSyncRound(reason = "foreground_resume")
+    }
   }
 
   override fun onHostPause() {
@@ -1090,6 +1101,11 @@ class NativeSyncEngineModule(
     val customTimeFrom = params.getStringOrNull("customTimeFrom")
       ?.takeIf { it.isNotBlank() }
       ?: currentConfig.customTimeFrom
+    val rangeStartAt = when {
+      timeRangeMode != "from_now" -> null
+      params.hasKey("timeRangeMode") -> isoNow()
+      else -> currentConfig.rangeStartAt ?: isoNow()
+    }
     val state = when {
       !enabled -> "disabled"
       currentConfig.state == "disabled" -> "active"
@@ -1101,6 +1117,7 @@ class NativeSyncEngineModule(
       state = state,
       timeRangeMode = timeRangeMode,
       customTimeFrom = customTimeFrom,
+      rangeStartAt = rangeStartAt,
     )
     val shouldStartRound = AndroidSyncPrimitives.shouldStartAutoUploadRound(
       previousEnabled = currentConfig.enabled,
@@ -1864,16 +1881,28 @@ class NativeSyncEngineModule(
         emitError("ANDROID_PHOTO_PERMISSION_DENIED", "Android photo permission is not enabled, so sync media cannot be scanned.")
         return
       }
-      val config = loadAutoUploadConfig()
-      recordDiagnosticsLog(
-        "Sync",
-        "round requested reason=$reason autoEnabled=${config.enabled} autoState=${config.state}",
-      )
+      var config = loadAutoUploadConfig()
       if (!config.enabled) {
         recordDiagnosticsLog("Sync", "round ignored reason=$reason auto upload disabled")
         emitIdleSyncState(binding)
         return
       }
+      if (config.timeRangeMode == "from_now" && config.rangeStartAt.isNullOrBlank()) {
+        config = config.copy(rangeStartAt = isoNow())
+        saveAutoUploadConfig(config)
+      }
+      val scanThresholdEpochSeconds = AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+        timeRangeMode = config.timeRangeMode,
+        customTimeFrom = config.customTimeFrom,
+        rangeStartAt = config.rangeStartAt,
+        nowEpochMillis = System.currentTimeMillis(),
+        timeZoneId = TimeZone.getDefault().id,
+      )
+      recordDiagnosticsLog(
+        "Sync",
+        "round requested reason=$reason autoEnabled=${config.enabled} autoState=${config.state} " +
+          "timeRangeMode=${config.timeRangeMode} scanThresholdEpochSeconds=$scanThresholdEpochSeconds",
+      )
       val roundStartRuntimeDecision = currentForegroundLanRuntimeDecision()
       if (!roundStartRuntimeDecision.canContinue) {
         val stopReason = roundStartRuntimeDecision.reason ?: "foreground_lan_runtime_inactive"
@@ -1893,7 +1922,7 @@ class NativeSyncEngineModule(
       val existingAssetIds = existing
         .filter { it.status in ACTIVE_UPLOAD_STATUSES }
         .mapTo(mutableSetOf()) { it.assetLocalId }
-      val discovered = mediaStoreRepository.scanAssets(clientId)
+      val discovered = mediaStoreRepository.scanAssets(clientId, scanThresholdEpochSeconds)
         .filter { it.assetLocalId !in existingAssetIds }
       if (discovered.isNotEmpty() && config.enabled) {
         uploadStore.upsertItems(discovered.map { it.copy(source = "auto", status = "queued", updatedAt = isoNow()) })
@@ -5346,6 +5375,8 @@ class NativeSyncEngineModule(
         ?: "all",
       customTimeFrom = prefs.getString(PREF_AUTO_UPLOAD_CUSTOM_TIME_FROM, null)
         ?.takeIf { it.isNotBlank() },
+      rangeStartAt = prefs.getString(PREF_AUTO_UPLOAD_RANGE_START_AT, null)
+        ?.takeIf { it.isNotBlank() },
     )
   }
 
@@ -5373,6 +5404,11 @@ class NativeSyncEngineModule(
       editor.remove(PREF_AUTO_UPLOAD_CUSTOM_TIME_FROM)
     } else {
       editor.putString(PREF_AUTO_UPLOAD_CUSTOM_TIME_FROM, config.customTimeFrom)
+    }
+    if (config.rangeStartAt.isNullOrBlank()) {
+      editor.remove(PREF_AUTO_UPLOAD_RANGE_START_AT)
+    } else {
+      editor.putString(PREF_AUTO_UPLOAD_RANGE_START_AT, config.rangeStartAt)
     }
     editor.apply()
   }
@@ -6416,6 +6452,7 @@ class NativeSyncEngineModule(
     val state: String,
     val timeRangeMode: String,
     val customTimeFrom: String?,
+    val rangeStartAt: String?,
   )
 
   private class NativeBridgeException(
@@ -6464,6 +6501,7 @@ class NativeSyncEngineModule(
     private const val PREF_AUTO_UPLOAD_STATE = "auto_upload_state"
     private const val PREF_AUTO_UPLOAD_TIME_RANGE_MODE = "auto_upload_time_range_mode"
     private const val PREF_AUTO_UPLOAD_CUSTOM_TIME_FROM = "auto_upload_custom_time_from"
+    private const val PREF_AUTO_UPLOAD_RANGE_START_AT = "auto_upload_range_start_at"
     /** Auth-layer EncryptedSharedPreferences file (react-native-keychain service).
      *  Mirror of the iOS Keychain service `com.lynavo.drive.auth`. */
     const val AUTH_KEYCHAIN_PREFS_NAME = "com.lynavo.drive.auth"

--- a/apps/mobile/android/app/src/test/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitivesTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitivesTest.kt
@@ -10,8 +10,8 @@ import org.junit.Test
 
 class AndroidSyncPrimitivesTest {
   @Test
-  fun fromNowAutoUploadUsesPersistedRangeStartAsScanThreshold() {
-    val threshold = AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+  fun fromNowAutoUploadUsesPersistedRangeStartAsCreationTimeThreshold() {
+    val threshold = AndroidSyncPrimitives.autoUploadScanThresholdEpochMillis(
       timeRangeMode = "from_now",
       customTimeFrom = null,
       rangeStartAt = "2026-07-22T04:05:06.789Z",
@@ -19,12 +19,12 @@ class AndroidSyncPrimitivesTest {
       timeZoneId = "UTC",
     )
 
-    assertEquals(1_784_693_106L, threshold)
+    assertEquals(1_784_693_106_789L, threshold)
   }
 
   @Test
-  fun customAutoUploadParsesJavaScriptFractionalTimestampAsScanThreshold() {
-    val threshold = AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+  fun customAutoUploadParsesJavaScriptFractionalTimestampAsCreationTimeThreshold() {
+    val threshold = AndroidSyncPrimitives.autoUploadScanThresholdEpochMillis(
       timeRangeMode = "custom",
       customTimeFrom = "2026-06-16T03:04:05.000Z",
       rangeStartAt = null,
@@ -32,12 +32,12 @@ class AndroidSyncPrimitivesTest {
       timeZoneId = "UTC",
     )
 
-    assertEquals(1_781_579_045L, threshold)
+    assertEquals(1_781_579_045_000L, threshold)
   }
 
   @Test
-  fun fromTodayAutoUploadUsesStartOfLocalDayAsScanThreshold() {
-    val threshold = AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+  fun fromTodayAutoUploadUsesStartOfLocalDayAsCreationTimeThreshold() {
+    val threshold = AndroidSyncPrimitives.autoUploadScanThresholdEpochMillis(
       timeRangeMode = "from_today",
       customTimeFrom = null,
       rangeStartAt = null,
@@ -45,13 +45,13 @@ class AndroidSyncPrimitivesTest {
       timeZoneId = "Asia/Taipei",
     )
 
-    assertEquals(1_784_649_600L, threshold)
+    assertEquals(1_784_649_600_000L, threshold)
   }
 
   @Test
   fun allAutoUploadDoesNotApplyScanThreshold() {
     assertNull(
-      AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+      AndroidSyncPrimitives.autoUploadScanThresholdEpochMillis(
         timeRangeMode = "all",
         customTimeFrom = null,
         rangeStartAt = null,
@@ -59,6 +59,16 @@ class AndroidSyncPrimitivesTest {
         timeZoneId = "UTC",
       ),
     )
+  }
+
+  @Test
+  fun autoUploadCreationTimeFilterUsesMediaCaptureTime() {
+    val filter = AndroidSyncPrimitives.autoUploadCreationTimeFilter(
+      thresholdEpochMillis = 1_784_693_106_789L,
+    )
+
+    assertEquals("datetaken>=?", filter?.selection)
+    assertEquals("1784693106789", filter?.selectionArg)
   }
 
   @Test

--- a/apps/mobile/android/app/src/test/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitivesTest.kt
+++ b/apps/mobile/android/app/src/test/java/com/lynavo/drive/mobile/sync/AndroidSyncPrimitivesTest.kt
@@ -10,6 +10,83 @@ import org.junit.Test
 
 class AndroidSyncPrimitivesTest {
   @Test
+  fun fromNowAutoUploadUsesPersistedRangeStartAsScanThreshold() {
+    val threshold = AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+      timeRangeMode = "from_now",
+      customTimeFrom = null,
+      rangeStartAt = "2026-07-22T04:05:06.789Z",
+      nowEpochMillis = 0,
+      timeZoneId = "UTC",
+    )
+
+    assertEquals(1_784_693_106L, threshold)
+  }
+
+  @Test
+  fun customAutoUploadParsesJavaScriptFractionalTimestampAsScanThreshold() {
+    val threshold = AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+      timeRangeMode = "custom",
+      customTimeFrom = "2026-06-16T03:04:05.000Z",
+      rangeStartAt = null,
+      nowEpochMillis = 0,
+      timeZoneId = "UTC",
+    )
+
+    assertEquals(1_781_579_045L, threshold)
+  }
+
+  @Test
+  fun fromTodayAutoUploadUsesStartOfLocalDayAsScanThreshold() {
+    val threshold = AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+      timeRangeMode = "from_today",
+      customTimeFrom = null,
+      rangeStartAt = null,
+      nowEpochMillis = 1_784_693_106_000L,
+      timeZoneId = "Asia/Taipei",
+    )
+
+    assertEquals(1_784_649_600L, threshold)
+  }
+
+  @Test
+  fun allAutoUploadDoesNotApplyScanThreshold() {
+    assertNull(
+      AndroidSyncPrimitives.autoUploadScanThresholdEpochSeconds(
+        timeRangeMode = "all",
+        customTimeFrom = null,
+        rangeStartAt = null,
+        nowEpochMillis = 0,
+        timeZoneId = "UTC",
+      ),
+    )
+  }
+
+  @Test
+  fun activeAutoUploadRescansWhenHostReturnsToForeground() {
+    assertTrue(
+      AndroidSyncPrimitives.shouldRescanAutoUploadOnHostResume(
+        wasVisible = false,
+        enabled = true,
+        state = "active",
+      ),
+    )
+    assertFalse(
+      AndroidSyncPrimitives.shouldRescanAutoUploadOnHostResume(
+        wasVisible = true,
+        enabled = true,
+        state = "active",
+      ),
+    )
+    assertFalse(
+      AndroidSyncPrimitives.shouldRescanAutoUploadOnHostResume(
+        wasVisible = false,
+        enabled = true,
+        state = "interrupted",
+      ),
+    )
+  }
+
+  @Test
   fun publicDownloadResultKeepsSavedLocationWhenContentUriIsHidden() {
     val result = AndroidSyncPrimitives.publicDownloadResult(
       exposeContentUri = false,

--- a/apps/mobile/src/i18n/locales/en/syncActivity.json
+++ b/apps/mobile/src/i18n/locales/en/syncActivity.json
@@ -201,7 +201,7 @@
     "selectedCountLabel": "{{count}} items",
     "removeFileLabel": "Remove {{name}}",
     "enableSwitchTitle": "Auto Upload Switch",
-    "enableSwitchDescOn": "Enabled. Will automatically sync new library content based on sync range.",
+    "enableSwitchDescOn": "Enabled. Album content will sync automatically.",
     "enableSwitchDescOff": "Disabled. Will not automatically sync new library content.",
     "sourcesTitle": "Sync Sources",
     "albumTitle": "Photos and Videos",

--- a/apps/mobile/src/i18n/locales/zh-Hans/syncActivity.json
+++ b/apps/mobile/src/i18n/locales/zh-Hans/syncActivity.json
@@ -201,7 +201,7 @@
     "selectedCountLabel": "{{count}} 个项目",
     "removeFileLabel": "移除 {{name}}",
     "enableSwitchTitle": "自动上传开关",
-    "enableSwitchDescOn": "已开启，会按同步范围自动同步相册新增素材",
+    "enableSwitchDescOn": "已开启，会自动同步相册内容",
     "enableSwitchDescOff": "已关闭，不会自动同步相册新增素材",
     "sourcesTitle": "同步来源",
     "albumTitle": "照片和视频",

--- a/apps/mobile/src/i18n/locales/zh-Hant/syncActivity.json
+++ b/apps/mobile/src/i18n/locales/zh-Hant/syncActivity.json
@@ -201,7 +201,7 @@
     "selectedCountLabel": "{{count}} 個項目",
     "removeFileLabel": "移除 {{name}}",
     "enableSwitchTitle": "自動上傳開關",
-    "enableSwitchDescOn": "已開啟，會按同步範圍自動同步相簿新增素材",
+    "enableSwitchDescOn": "已開啟，會自動同步相簿內容",
     "enableSwitchDescOff": "已關閉，不會自動同步相簿新增素材",
     "sourcesTitle": "同步來源",
     "albumTitle": "照片和影片",

--- a/apps/mobile/src/screens/AutoUploadSettingsScreen.tsx
+++ b/apps/mobile/src/screens/AutoUploadSettingsScreen.tsx
@@ -11,28 +11,19 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
-  Platform,
   Alert,
-  Modal,
   Switch,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, CommonActions } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import {
-  Calendar,
   Check,
   ChevronLeft,
-  Clock,
   CloudDownload,
-  Folder,
   Image as ImageIcon,
   ShieldCheck,
 } from 'lucide-react-native';
-import DateTimePicker, {
-  DateTimePickerEvent,
-} from '@react-native-community/datetimepicker';
-import type { AutoUploadTimeRangeMode } from '@lynavo-drive/contracts';
 
 import { GradientBackground } from '../components/GradientBackground';
 import { androidBoxShadow } from '../utils/androidShadow';
@@ -44,33 +35,21 @@ import {
   saveAutoUploadConfig,
 } from '../services/SyncEngineModule';
 
-type AutoUploadRange = 'all' | 'now' | 'custom';
-type AndroidPickerMode = 'date' | 'time';
-
 const BLUE = '#1677D2';
 const DARK = '#17191C';
-const MUTED_ICON = '#7B8490';
 const FALLBACK_COPY = {
   title: 'Auto Upload',
   subtitle: 'Set up phone content sync to computer',
   planTitle: 'Sync Plan',
   enableSwitchTitle: 'Auto Upload Switch',
-  enableSwitchDescOn:
-    'Enabled. New album media will sync automatically based on sync range',
+  enableSwitchDescOn: 'Enabled. Album content will sync automatically',
   enableSwitchDescOff: 'Disabled. New album media will not sync automatically',
   sourcesTitle: 'Sync Sources',
   albumTitle: 'Photos and Videos',
   albumDesc: 'Sync media content from system album',
-  rangeTitle: 'Sync Range',
   rangeAllTitle: 'All Content',
-  rangeAllDesc: 'Sync existing photos and videos',
-  rangeNowTitle: 'From Now On',
-  rangeNowDesc: 'Only sync newly added content from now on',
-  rangeCustomTitle: 'Custom Time',
-  rangeCustomDesc: 'Sync from the specified start time',
   confirmEnable: 'Enable Auto Upload',
   confirmDisable: 'Disable Auto Upload',
-  customPickerSave: 'Save',
   infoAlbum: 'Album photos and videos will sync to your computer.',
   infoAutoOff:
     'After auto upload is disabled, newly added media will not sync.',
@@ -80,34 +59,6 @@ const FALLBACK_COPY = {
     'Failed to read auto upload settings. Please try again later.',
   disabledSuccess: 'Auto upload is disabled',
 };
-
-function toUploadRange(mode: AutoUploadTimeRangeMode): AutoUploadRange {
-  if (mode === 'custom') return 'custom';
-  if (mode === 'from_now' || mode === 'from_today') return 'now';
-  return 'all';
-}
-
-function toTimeRangeMode(range: AutoUploadRange): AutoUploadTimeRangeMode {
-  if (range === 'now') return 'from_now';
-  return range;
-}
-
-function resolveTimeRangeMode(
-  range: AutoUploadRange,
-  hydratedMode: AutoUploadTimeRangeMode,
-  rangeEdited: boolean,
-): AutoUploadTimeRangeMode {
-  if (!rangeEdited && hydratedMode === 'from_today' && range === 'now') {
-    return 'from_today';
-  }
-  return toTimeRangeMode(range);
-}
-
-function parseConfigDate(value?: string): Date | null {
-  if (!value) return null;
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date;
-}
 
 export function AutoUploadSettingsScreen() {
   const navigation = useNavigation();
@@ -139,36 +90,15 @@ export function AutoUploadSettingsScreen() {
       albumDesc:
         t('syncActivity.autoUploadSettings.albumDesc') ||
         FALLBACK_COPY.albumDesc,
-      rangeTitle:
-        t('syncActivity.autoUploadSettings.rangeTitle') ||
-        FALLBACK_COPY.rangeTitle,
       rangeAllTitle:
         t('syncActivity.autoUploadSettings.rangeAllTitle') ||
         FALLBACK_COPY.rangeAllTitle,
-      rangeAllDesc:
-        t('syncActivity.autoUploadSettings.rangeAllDesc') ||
-        FALLBACK_COPY.rangeAllDesc,
-      rangeNowTitle:
-        t('syncActivity.autoUploadSettings.rangeNowTitle') ||
-        FALLBACK_COPY.rangeNowTitle,
-      rangeNowDesc:
-        t('syncActivity.autoUploadSettings.rangeNowDesc') ||
-        FALLBACK_COPY.rangeNowDesc,
-      rangeCustomTitle:
-        t('syncActivity.autoUploadSettings.rangeCustomTitle') ||
-        FALLBACK_COPY.rangeCustomTitle,
-      rangeCustomDesc:
-        t('syncActivity.autoUploadSettings.rangeCustomDesc') ||
-        FALLBACK_COPY.rangeCustomDesc,
       confirmEnable:
         t('syncActivity.autoUploadSettings.confirmEnable') ||
         FALLBACK_COPY.confirmEnable,
       confirmDisable:
         t('syncActivity.autoUploadSettings.confirmDisable') ||
         FALLBACK_COPY.confirmDisable,
-      customPickerSave:
-        t('syncActivity.autoUploadSettings.customPickerSave') ||
-        FALLBACK_COPY.customPickerSave,
       infoAlbum:
         t('syncActivity.autoUploadSettings.infoAlbum') ||
         FALLBACK_COPY.infoAlbum,
@@ -194,15 +124,6 @@ export function AutoUploadSettingsScreen() {
   const [autoUploadEnabled, setAutoUploadEnabled] = useState(false);
   const [persistedAutoUploadEnabled, setPersistedAutoUploadEnabled] =
     useState(false);
-  const [uploadRange, setUploadRange] = useState<AutoUploadRange>('all');
-  const [hydratedTimeRangeMode, setHydratedTimeRangeMode] =
-    useState<AutoUploadTimeRangeMode>('all');
-  const [rangeEdited, setRangeEdited] = useState(false);
-  const [showDatePicker, setShowDatePicker] = useState(false);
-  const [androidPickerMode, setAndroidPickerMode] =
-    useState<AndroidPickerMode>('date');
-  const [customDate, setCustomDate] = useState<Date>(new Date());
-  const [tempDate, setTempDate] = useState<Date>(new Date());
   const [configLoading, setConfigLoading] = useState(true);
   const [configError, setConfigError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -222,15 +143,6 @@ export function AutoUploadSettingsScreen() {
 
         setPersistedAutoUploadEnabled(config.enabled);
         setAutoUploadEnabled(config.enabled);
-        setHydratedTimeRangeMode(config.timeRangeMode);
-        setRangeEdited(false);
-        setUploadRange(toUploadRange(config.timeRangeMode));
-
-        const parsedDate = parseConfigDate(config.customTimeFrom);
-        if (parsedDate) {
-          setCustomDate(parsedDate);
-          setTempDate(parsedDate);
-        }
         setConfigError(null);
       } catch (e) {
         console.warn('[AutoUploadSettings] getAutoUploadConfig failed:', e);
@@ -251,22 +163,11 @@ export function AutoUploadSettingsScreen() {
     };
   }, [copy.loadConfigFailed]);
 
-  const persistAlbumAutoUploadConfig = async (
-    range: AutoUploadRange,
-    date: Date,
-    edited: boolean,
-  ) => {
+  const persistAlbumAutoUploadConfig = async () => {
     if (savingRef.current) return;
     savingRef.current = true;
     try {
       setSaving(true);
-      const timeRangeMode = resolveTimeRangeMode(
-        range,
-        hydratedTimeRangeMode,
-        edited,
-      );
-      const customTimeFrom =
-        timeRangeMode === 'custom' ? date.toISOString() : undefined;
       const wasPersistedEnabled = persistedAutoUploadEnabled;
 
       if (!wasPersistedEnabled) {
@@ -274,16 +175,14 @@ export function AutoUploadSettingsScreen() {
       }
       await saveAutoUploadConfig({
         enabled: true,
-        timeRangeMode,
-        customTimeFrom,
+        timeRangeMode: 'all',
+        customTimeFrom: undefined,
       });
       if (!wasPersistedEnabled) {
         await enableAutoUpload({ skipPermissionPreflight: true });
       }
       setPersistedAutoUploadEnabled(true);
       setAutoUploadEnabled(true);
-      setHydratedTimeRangeMode(timeRangeMode);
-      setRangeEdited(false);
     } catch (e) {
       console.warn('[AutoUploadSettings] save auto upload config failed:', e);
       if (!persistedAutoUploadEnabled) {
@@ -326,7 +225,7 @@ export function AutoUploadSettingsScreen() {
       }
       return;
     }
-    await persistAlbumAutoUploadConfig(uploadRange, customDate, rangeEdited);
+    await persistAlbumAutoUploadConfig();
   };
 
   const handleBack = useCallback(() => {
@@ -343,66 +242,6 @@ export function AutoUploadSettingsScreen() {
     );
   }, [navigation]);
 
-  const handleRangeSelect = (range: AutoUploadRange) => {
-    setRangeEdited(true);
-    setUploadRange(range);
-    if (range === 'custom') {
-      setTempDate(customDate);
-      setAndroidPickerMode('date');
-      setShowDatePicker(true);
-      return;
-    }
-    if (autoUploadEnabled) {
-      void persistAlbumAutoUploadConfig(range, customDate, true);
-    }
-  };
-
-  const handleDateChange = (
-    event: DateTimePickerEvent,
-    selectedDate?: Date,
-  ) => {
-    if (Platform.OS === 'android') {
-      if (event.type !== 'set' || !selectedDate) {
-        setShowDatePicker(false);
-        return;
-      }
-      if (androidPickerMode === 'date') {
-        const nextDate = new Date(tempDate);
-        nextDate.setFullYear(
-          selectedDate.getFullYear(),
-          selectedDate.getMonth(),
-          selectedDate.getDate(),
-        );
-        setTempDate(nextDate);
-        setAndroidPickerMode('time');
-        return;
-      }
-      const nextDate = new Date(tempDate);
-      nextDate.setHours(
-        selectedDate.getHours(),
-        selectedDate.getMinutes(),
-        0,
-        0,
-      );
-      setCustomDate(nextDate);
-      setTempDate(nextDate);
-      setShowDatePicker(false);
-      if (autoUploadEnabled) {
-        void persistAlbumAutoUploadConfig('custom', nextDate, true);
-      }
-    } else if (selectedDate) {
-      setTempDate(selectedDate);
-    }
-  };
-
-  const handleConfirmDatePicker = () => {
-    setCustomDate(tempDate);
-    setShowDatePicker(false);
-    if (autoUploadEnabled) {
-      void persistAlbumAutoUploadConfig('custom', tempDate, true);
-    }
-  };
-
   // Render dynamic explanation sentence
   const renderInfoText = () => {
     if (configLoading) {
@@ -417,14 +256,8 @@ export function AutoUploadSettingsScreen() {
     return copy.infoAlbum;
   };
 
-  const activeRangeLabel =
-    uploadRange === 'all'
-      ? copy.rangeAllTitle
-      : uploadRange === 'now'
-        ? copy.rangeNowTitle
-        : copy.rangeCustomTitle;
   const planRangeLabel = autoUploadEnabled
-    ? activeRangeLabel
+    ? copy.rangeAllTitle
     : t('common.notApplicable') || 'N/A';
   const infoText = renderInfoText();
 
@@ -524,170 +357,35 @@ export function AutoUploadSettingsScreen() {
           </View>
 
           {autoUploadEnabled ? (
-            <>
-              {/* Synchronize Source */}
-              <View style={styles.section}>
-                <View style={styles.sectionHeaderRow}>
-                  <Text style={styles.sectionTitle}>{copy.sourcesTitle}</Text>
-                </View>
-                <View style={styles.cardContainer}>
-                  {/* Option 1: Album */}
-                  <View
-                    style={[styles.optionRow, styles.optionRowActive]}
-                    testID="auto-upload-source-album"
-                    accessibilityState={{ selected: true }}
-                  >
-                    <View style={[styles.sourceIconBox, styles.iconBoxActive]}>
-                      <ImageIcon
-                        testID="auto-upload-source-album-icon"
-                        size={20}
-                        color="#fff"
-                        strokeWidth={1.9}
-                      />
-                    </View>
-                    <View style={styles.optionInfo}>
-                      <Text style={styles.optionTitle}>{copy.albumTitle}</Text>
-                      <Text style={styles.optionDesc}>{copy.albumDesc}</Text>
-                    </View>
-                    <SelectionIndicator
-                      selected
-                      testID="auto-upload-source-album-check-icon"
+            <View style={styles.section}>
+              <View style={styles.sectionHeaderRow}>
+                <Text style={styles.sectionTitle}>{copy.sourcesTitle}</Text>
+              </View>
+              <View style={styles.cardContainer}>
+                <View
+                  style={[styles.optionRow, styles.optionRowActive]}
+                  testID="auto-upload-source-album"
+                  accessibilityState={{ selected: true }}
+                >
+                  <View style={[styles.sourceIconBox, styles.iconBoxActive]}>
+                    <ImageIcon
+                      testID="auto-upload-source-album-icon"
+                      size={20}
+                      color="#fff"
+                      strokeWidth={1.9}
                     />
                   </View>
+                  <View style={styles.optionInfo}>
+                    <Text style={styles.optionTitle}>{copy.albumTitle}</Text>
+                    <Text style={styles.optionDesc}>{copy.albumDesc}</Text>
+                  </View>
+                  <SelectionIndicator
+                    selected
+                    testID="auto-upload-source-album-check-icon"
+                  />
                 </View>
               </View>
-
-              {/* Upload Range */}
-              <View style={styles.section}>
-                <Text
-                  style={[styles.sectionTitle, styles.standaloneSectionTitle]}
-                >
-                  {copy.rangeTitle}
-                </Text>
-                <View style={styles.cardContainer}>
-                  {/* Option: All */}
-                  <TouchableOpacity
-                    style={[
-                      styles.optionRow,
-                      uploadRange === 'all' && styles.optionRowActive,
-                    ]}
-                    activeOpacity={0.8}
-                    testID="auto-upload-range-all"
-                    accessibilityRole="button"
-                    accessibilityState={{ selected: uploadRange === 'all' }}
-                    onPress={() => handleRangeSelect('all')}
-                  >
-                    <View
-                      style={[
-                        styles.rangeIconBox,
-                        uploadRange === 'all'
-                          ? styles.iconBoxActive
-                          : styles.iconBoxInactive,
-                      ]}
-                    >
-                      <Folder
-                        testID="auto-upload-range-all-icon"
-                        size={18}
-                        color={uploadRange === 'all' ? '#fff' : MUTED_ICON}
-                        strokeWidth={1.9}
-                      />
-                    </View>
-                    <View style={styles.optionInfo}>
-                      <Text style={styles.optionTitle}>
-                        {copy.rangeAllTitle}
-                      </Text>
-                      <Text style={styles.optionDesc}>{copy.rangeAllDesc}</Text>
-                    </View>
-                    <SelectionIndicator
-                      selected={uploadRange === 'all'}
-                      testID="auto-upload-range-all-check-icon"
-                    />
-                  </TouchableOpacity>
-
-                  {/* Option: Now */}
-                  <TouchableOpacity
-                    style={[
-                      styles.optionRow,
-                      uploadRange === 'now' && styles.optionRowActive,
-                    ]}
-                    activeOpacity={0.8}
-                    testID="auto-upload-range-now"
-                    accessibilityRole="button"
-                    accessibilityState={{ selected: uploadRange === 'now' }}
-                    onPress={() => handleRangeSelect('now')}
-                  >
-                    <View
-                      style={[
-                        styles.rangeIconBox,
-                        uploadRange === 'now'
-                          ? styles.iconBoxActive
-                          : styles.iconBoxInactive,
-                      ]}
-                    >
-                      <Clock
-                        testID="auto-upload-range-now-icon"
-                        size={18}
-                        color={uploadRange === 'now' ? '#fff' : MUTED_ICON}
-                        strokeWidth={1.9}
-                      />
-                    </View>
-                    <View style={styles.optionInfo}>
-                      <Text style={styles.optionTitle}>
-                        {copy.rangeNowTitle}
-                      </Text>
-                      <Text style={styles.optionDesc}>{copy.rangeNowDesc}</Text>
-                    </View>
-                    <SelectionIndicator
-                      selected={uploadRange === 'now'}
-                      testID="auto-upload-range-now-check-icon"
-                    />
-                  </TouchableOpacity>
-
-                  {/* Option: Custom */}
-                  <TouchableOpacity
-                    style={[
-                      styles.optionRow,
-                      uploadRange === 'custom' && styles.optionRowActive,
-                    ]}
-                    activeOpacity={0.8}
-                    testID="auto-upload-range-custom"
-                    accessibilityRole="button"
-                    accessibilityState={{
-                      selected: uploadRange === 'custom',
-                    }}
-                    onPress={() => handleRangeSelect('custom')}
-                  >
-                    <View
-                      style={[
-                        styles.rangeIconBox,
-                        uploadRange === 'custom'
-                          ? styles.iconBoxActive
-                          : styles.iconBoxInactive,
-                      ]}
-                    >
-                      <Calendar
-                        testID="auto-upload-range-custom-icon"
-                        size={18}
-                        color={uploadRange === 'custom' ? '#fff' : MUTED_ICON}
-                        strokeWidth={1.9}
-                      />
-                    </View>
-                    <View style={styles.optionInfo}>
-                      <Text style={styles.optionTitle}>
-                        {copy.rangeCustomTitle}
-                      </Text>
-                      <Text style={styles.optionDesc}>
-                        {copy.rangeCustomDesc}
-                      </Text>
-                    </View>
-                    <SelectionIndicator
-                      selected={uploadRange === 'custom'}
-                      testID="auto-upload-range-custom-check-icon"
-                    />
-                  </TouchableOpacity>
-                </View>
-              </View>
-            </>
+            </View>
           ) : null}
 
           {/* Info Card */}
@@ -704,50 +402,6 @@ export function AutoUploadSettingsScreen() {
           </View>
         </ScrollView>
       </SafeAreaView>
-
-      {/* Date Picker Modal for iOS / Modal structure for Android */}
-      {showDatePicker && Platform.OS === 'ios' && (
-        <Modal transparent animationType="fade" visible={showDatePicker}>
-          <View style={styles.pickerOverlay}>
-            <View style={styles.pickerCard}>
-              <View style={styles.pickerHeader}>
-                <TouchableOpacity
-                  activeOpacity={0.6}
-                  onPress={() => setShowDatePicker(false)}
-                >
-                  <Text style={styles.pickerCancelText}>
-                    {t('common.cancel') || 'Cancel'}
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  activeOpacity={0.6}
-                  onPress={handleConfirmDatePicker}
-                >
-                  <Text style={styles.pickerConfirmText}>
-                    {copy.customPickerSave}
-                  </Text>
-                </TouchableOpacity>
-              </View>
-              <DateTimePicker
-                value={tempDate}
-                mode="datetime"
-                display="spinner"
-                onChange={handleDateChange}
-                style={styles.datePicker}
-              />
-            </View>
-          </View>
-        </Modal>
-      )}
-
-      {showDatePicker && Platform.OS === 'android' && (
-        <DateTimePicker
-          value={tempDate}
-          mode={androidPickerMode}
-          display="default"
-          onChange={handleDateChange}
-        />
-      )}
     </GradientBackground>
   );
 }
@@ -924,9 +578,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#7B8490',
   },
-  standaloneSectionTitle: {
-    marginBottom: 10,
-  },
   cardContainer: {
     gap: 12,
   },
@@ -961,18 +612,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  rangeIconBox: {
-    width: 40,
-    height: 40,
-    borderRadius: 12,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   iconBoxActive: {
     backgroundColor: '#1677D2',
-  },
-  iconBoxInactive: {
-    backgroundColor: 'rgba(255,255,255,0.72)',
   },
   optionInfo: {
     flex: 1,
@@ -1041,38 +682,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
     lineHeight: 22,
     color: '#3F4A58',
-  },
-  // Date Picker iOS styles
-  pickerOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'flex-end',
-  },
-  pickerCard: {
-    backgroundColor: '#fff',
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    paddingBottom: Platform.OS === 'ios' ? 30 : 16,
-  },
-  pickerHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: '#edf2f7',
-  },
-  pickerCancelText: {
-    fontSize: 15,
-    color: '#718096',
-  },
-  pickerConfirmText: {
-    fontSize: 15,
-    color: '#1D4ED8',
-    fontWeight: '600',
-  },
-  datePicker: {
-    height: 200,
-    width: '100%',
   },
 });
 

--- a/apps/mobile/src/screens/__tests__/AutoUploadSettingsScreen.test.tsx
+++ b/apps/mobile/src/screens/__tests__/AutoUploadSettingsScreen.test.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
-import {
-  Alert,
-  Platform,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-} from 'react-native';
+import { Alert, StyleSheet, Text, TouchableOpacity } from 'react-native';
 import {
   disableAutoUpload,
   enableAutoUpload,
@@ -18,7 +12,6 @@ import {
 const mockGoBack = jest.fn();
 const mockDispatch = jest.fn();
 const mockCanGoBack = jest.fn();
-const originalPlatformOS = Platform.OS;
 
 jest.mock('@react-navigation/native', () => ({
   CommonActions: {
@@ -30,8 +23,6 @@ jest.mock('@react-navigation/native', () => ({
     canGoBack: mockCanGoBack,
   }),
 }));
-
-jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
 
 jest.mock('react-native-safe-area-context', () => ({
   SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
@@ -54,12 +45,9 @@ jest.mock('lucide-react-native', () => {
         ...props,
       });
   return {
-    Calendar: createIcon('mock-calendar-icon'),
     Check: createIcon('mock-check-icon'),
     ChevronLeft: createIcon('mock-chevron-left-icon'),
-    Clock: createIcon('mock-clock-icon'),
     CloudDownload: createIcon('mock-cloud-download-icon'),
-    Folder: createIcon('mock-folder-icon'),
     Image: createIcon('mock-image-icon'),
     ShieldCheck: createIcon('mock-shield-check-icon'),
   };
@@ -88,24 +76,14 @@ jest.mock('react-i18next', () => ({
         'syncActivity.autoUploadSettings.enableSwitchTitle':
           'Auto Upload Switch',
         'syncActivity.autoUploadSettings.enableSwitchDescOn':
-          'Enabled. New album media will sync automatically based on sync range',
+          'Enabled. Album content will sync automatically',
         'syncActivity.autoUploadSettings.enableSwitchDescOff':
           'Disabled. New album media will not sync automatically',
         'syncActivity.autoUploadSettings.sourcesTitle': 'Sync Sources',
         'syncActivity.autoUploadSettings.albumTitle': 'Photos and Videos',
         'syncActivity.autoUploadSettings.albumDesc':
           'Sync media content from system album',
-        'syncActivity.autoUploadSettings.rangeTitle': 'Sync Range',
         'syncActivity.autoUploadSettings.rangeAllTitle': 'All Content',
-        'syncActivity.autoUploadSettings.rangeAllDesc':
-          'Sync existing photos and videos',
-        'syncActivity.autoUploadSettings.rangeNowTitle': 'From Now On',
-        'syncActivity.autoUploadSettings.rangeNowDesc':
-          'Only sync newly added content from now on',
-        'syncActivity.autoUploadSettings.rangeCustomTitle': 'CustomTime',
-        'syncActivity.autoUploadSettings.rangeCustomDesc':
-          'Sync from the specified start time',
-        'syncActivity.autoUploadSettings.customPickerSave': 'Save',
         'syncActivity.autoUploadSettings.infoAlbum':
           'Album photos and videos will sync to your computer.',
         'syncActivity.autoUploadSettings.infoAutoOff':
@@ -118,7 +96,6 @@ jest.mock('react-i18next', () => ({
         'syncActivity.dialogs.enableAutoFailed.body':
           'Could not enable auto upload. Please try again later',
         'common.back': 'Back',
-        'common.cancel': 'Cancel',
         'common.notApplicable': 'N/A',
       };
       return copy[key] ?? '';
@@ -174,10 +151,6 @@ describe('AutoUploadSettingsScreen', () => {
   });
 
   afterEach(() => {
-    Object.defineProperty(Platform, 'OS', {
-      configurable: true,
-      value: originalPlatformOS,
-    });
     jest.restoreAllMocks();
   });
 
@@ -188,15 +161,18 @@ describe('AutoUploadSettingsScreen', () => {
     expect(textValues).toContain('Sync Plan');
     expect(textValues).toContain('Auto Upload Switch');
     expect(textValues).toContain(
+      'Enabled. Album content will sync automatically',
+    );
+    expect(textValues).toContain(
       'Album photos and videos will sync to your computer.',
     );
     expect(textValues).toContain('Sync Sources');
     expect(textValues).toContain('Photos and Videos');
     expect(textValues).toContain('Sync media content from system album');
-    expect(textValues).toContain('Sync Range');
-    expect(textValues).toContain('Sync existing photos and videos');
-    expect(textValues).toContain('Only sync newly added content from now on');
-    expect(textValues).toContain('CustomTime');
+    expect(textValues).toContain('All Content');
+    expect(textValues).not.toContain('Sync Range');
+    expect(textValues).not.toContain('From Now On');
+    expect(textValues).not.toContain('CustomTime');
     expect(textValues).not.toContain('Specified Files');
     expect(textValues).not.toContain(
       'Select content to sync from system files',
@@ -211,6 +187,15 @@ describe('AutoUploadSettingsScreen', () => {
     ).toHaveLength(0);
     expect(
       tree.root.findAllByProps({ testID: 'auto-upload-source-file-icon' }),
+    ).toHaveLength(0);
+    expect(
+      tree.root.findAllByProps({ testID: 'auto-upload-range-all' }),
+    ).toHaveLength(0);
+    expect(
+      tree.root.findAllByProps({ testID: 'auto-upload-range-now' }),
+    ).toHaveLength(0);
+    expect(
+      tree.root.findAllByProps({ testID: 'auto-upload-range-custom' }),
     ).toHaveLength(0);
   });
 
@@ -227,7 +212,7 @@ describe('AutoUploadSettingsScreen', () => {
     expect(getAutoUploadSwitch(tree).props.value).toBe(true);
   });
 
-  it('hides source and range controls when the auto upload switch is off', async () => {
+  it('hides source controls when the auto upload switch is off', async () => {
     const tree = await renderScreen();
 
     await ReactTestRenderer.act(async () => {
@@ -238,30 +223,21 @@ describe('AutoUploadSettingsScreen', () => {
     expect(
       tree.root.findAllByProps({ testID: 'auto-upload-source-album' }),
     ).toHaveLength(0);
-    expect(
-      tree.root.findAllByProps({ testID: 'auto-upload-range-all' }),
-    ).toHaveLength(0);
     expect(getTextValues(tree)).toContain(
       'After auto upload is disabled, newly added media will not sync.',
     );
   });
 
-  it('uses reference-style source and range icons without file-source icons', async () => {
+  it('uses the reference-style source icon without file-source icons', async () => {
     const tree = await renderScreen();
     const albumIcon = tree.root.findByProps({
       testID: 'auto-upload-source-album-icon',
     });
-    const rangeAllIcon = tree.root.findByProps({
-      testID: 'auto-upload-range-all-icon',
-    });
-
     expect(
       tree.root.findByProps({ testID: 'auto-upload-plan-icon' }),
     ).toBeTruthy();
     expect(albumIcon.props.size).toBe(20);
     expect(albumIcon.props.color).toBe('#fff');
-    expect(rangeAllIcon.props.size).toBe(18);
-    expect(rangeAllIcon.props.color).toBe('#fff');
     expect(
       tree.root.findAllByProps({ testID: 'auto-upload-source-file-icon' }),
     ).toHaveLength(0);
@@ -278,12 +254,6 @@ describe('AutoUploadSettingsScreen', () => {
     const albumIcon = tree.root.findByProps({
       testID: 'auto-upload-source-album-icon',
     });
-    const rangeAllIcon = tree.root.findByProps({
-      testID: 'auto-upload-range-all-icon',
-    });
-    const rangeCustomSelectionBox = tree.root.findByProps({
-      testID: 'auto-upload-range-custom-check-icon-box',
-    });
 
     expect(StyleSheet.flatten(titleNode?.props.style)).toMatchObject({
       fontSize: 17,
@@ -295,20 +265,6 @@ describe('AutoUploadSettingsScreen', () => {
       width: 44,
       height: 44,
       borderRadius: 13,
-    });
-    expect(StyleSheet.flatten(rangeAllIcon.parent?.props.style)).toMatchObject({
-      width: 40,
-      height: 40,
-      borderRadius: 12,
-    });
-    expect(
-      StyleSheet.flatten(rangeCustomSelectionBox.props.style),
-    ).toMatchObject({
-      width: 24,
-      height: 24,
-      borderRadius: 8,
-      borderColor: '#C9D6E4',
-      backgroundColor: 'rgba(255,255,255,0.72)',
     });
   });
 
@@ -358,15 +314,11 @@ describe('AutoUploadSettingsScreen', () => {
       tree.root.findByProps({ testID: 'auto-upload-source-album' }).props
         .accessibilityState,
     ).toMatchObject({ selected: true });
-    expect(
-      tree.root.findByProps({ testID: 'auto-upload-range-custom' }).props
-        .accessibilityState,
-    ).toMatchObject({ selected: true });
     expect(mockedPrepareAutoUploadEnable).toHaveBeenCalledTimes(1);
     expect(mockedSaveAutoUploadConfig).toHaveBeenCalledWith({
       enabled: true,
-      timeRangeMode: 'custom',
-      customTimeFrom: '2026-06-16T03:04:05.000Z',
+      timeRangeMode: 'all',
+      customTimeFrom: undefined,
     });
     expect(mockedEnableAutoUpload).toHaveBeenCalledWith({
       skipPermissionPreflight: true,
@@ -390,146 +342,6 @@ describe('AutoUploadSettingsScreen', () => {
 
     expect(mockedPrepareAutoUploadEnable).not.toHaveBeenCalled();
     expect(mockedSaveAutoUploadConfig).not.toHaveBeenCalled();
-    expect(mockedEnableAutoUpload).not.toHaveBeenCalled();
-  });
-
-  it('opens the custom range picker UI when custom range is selected', async () => {
-    const tree = await renderScreen();
-
-    ReactTestRenderer.act(() => {
-      tree.root
-        .findByProps({ testID: 'auto-upload-range-custom' })
-        .props.onPress();
-    });
-
-    expect(
-      tree.root.findByProps({
-        testID: 'auto-upload-range-custom',
-      }).props.accessibilityState,
-    ).toMatchObject({ selected: true });
-    expect(getTextValues(tree)).toContain('Save');
-    expect(
-      tree.root.findAllByType(
-        'DateTimePicker' as unknown as React.ComponentType,
-      ),
-    ).toHaveLength(1);
-  });
-
-  it('starts Android custom time selection with the supported date picker mode', async () => {
-    Object.defineProperty(Platform, 'OS', {
-      configurable: true,
-      value: 'android',
-    });
-    const tree = await renderScreen();
-
-    ReactTestRenderer.act(() => {
-      tree.root
-        .findByProps({ testID: 'auto-upload-range-custom' })
-        .props.onPress();
-    });
-
-    const picker = tree.root.findByType(
-      'DateTimePicker' as unknown as React.ComponentType,
-    );
-    expect(picker.props.mode).toBe('date');
-  });
-
-  it('continues Android custom time selection with a time picker after the date is set', async () => {
-    Object.defineProperty(Platform, 'OS', {
-      configurable: true,
-      value: 'android',
-    });
-    const tree = await renderScreen();
-
-    ReactTestRenderer.act(() => {
-      tree.root
-        .findByProps({ testID: 'auto-upload-range-custom' })
-        .props.onPress();
-    });
-    ReactTestRenderer.act(() => {
-      tree.root
-        .findByType('DateTimePicker' as unknown as React.ComponentType)
-        .props.onChange({ type: 'set' }, new Date('2026-07-20T03:04:00.000Z'));
-    });
-
-    const picker = tree.root.findByType(
-      'DateTimePicker' as unknown as React.ComponentType,
-    );
-    expect(picker.props.mode).toBe('time');
-  });
-
-  it('persists the combined Android custom date and time selection', async () => {
-    Object.defineProperty(Platform, 'OS', {
-      configurable: true,
-      value: 'android',
-    });
-    const initialDate = new Date('2026-06-16T03:04:05.000Z');
-    const selectedDate = new Date(2026, 6, 20, 0, 0, 0, 0);
-    const selectedTime = new Date(2026, 0, 1, 14, 45, 0, 0);
-    const expectedDate = new Date(initialDate);
-    expectedDate.setFullYear(
-      selectedDate.getFullYear(),
-      selectedDate.getMonth(),
-      selectedDate.getDate(),
-    );
-    expectedDate.setHours(
-      selectedTime.getHours(),
-      selectedTime.getMinutes(),
-      0,
-      0,
-    );
-    mockedGetAutoUploadConfig.mockResolvedValueOnce({
-      enabled: true,
-      timeRangeMode: 'custom',
-      customTimeFrom: initialDate.toISOString(),
-      state: 'active',
-    });
-    const tree = await renderScreen();
-
-    ReactTestRenderer.act(() => {
-      tree.root
-        .findByProps({ testID: 'auto-upload-range-custom' })
-        .props.onPress();
-    });
-    ReactTestRenderer.act(() => {
-      tree.root
-        .findByType('DateTimePicker' as unknown as React.ComponentType)
-        .props.onChange({ type: 'set' }, selectedDate);
-    });
-    await ReactTestRenderer.act(async () => {
-      tree.root
-        .findByType('DateTimePicker' as unknown as React.ComponentType)
-        .props.onChange({ type: 'set' }, selectedTime);
-      await Promise.resolve();
-    });
-
-    expect(
-      tree.root.findAllByType(
-        'DateTimePicker' as unknown as React.ComponentType,
-      ),
-    ).toHaveLength(0);
-    expect(mockedSaveAutoUploadConfig).toHaveBeenCalledWith({
-      enabled: true,
-      timeRangeMode: 'custom',
-      customTimeFrom: expectedDate.toISOString(),
-    });
-  });
-
-  it('saves range changes immediately while auto upload is enabled', async () => {
-    const tree = await renderScreen();
-
-    await ReactTestRenderer.act(async () => {
-      await tree.root
-        .findByProps({ testID: 'auto-upload-range-now' })
-        .props.onPress();
-    });
-
-    expect(mockedSaveAutoUploadConfig).toHaveBeenCalledWith({
-      enabled: true,
-      timeRangeMode: 'from_now',
-      customTimeFrom: undefined,
-    });
-    expect(mockedPrepareAutoUploadEnable).not.toHaveBeenCalled();
     expect(mockedEnableAutoUpload).not.toHaveBeenCalled();
   });
 
@@ -579,7 +391,7 @@ describe('AutoUploadSettingsScreen', () => {
     expect(mockedPrepareAutoUploadEnable).toHaveBeenCalledTimes(1);
     expect(mockedSaveAutoUploadConfig).toHaveBeenCalledWith({
       enabled: true,
-      timeRangeMode: 'from_now',
+      timeRangeMode: 'all',
       customTimeFrom: undefined,
     });
     expect(mockedEnableAutoUpload).toHaveBeenCalledTimes(1);
@@ -614,7 +426,7 @@ describe('AutoUploadSettingsScreen', () => {
     expect(mockedEnableAutoUpload).not.toHaveBeenCalled();
   });
 
-  it('preserves hydrated from_today mode when the range is not edited', async () => {
+  it('normalizes a hydrated from_today mode when enabling auto upload', async () => {
     mockedGetAutoUploadConfig.mockResolvedValueOnce({
       enabled: false,
       timeRangeMode: 'from_today',
@@ -628,7 +440,7 @@ describe('AutoUploadSettingsScreen', () => {
 
     expect(mockedSaveAutoUploadConfig).toHaveBeenCalledWith({
       enabled: true,
-      timeRangeMode: 'from_today',
+      timeRangeMode: 'all',
       customTimeFrom: undefined,
     });
     expect(mockedEnableAutoUpload).toHaveBeenCalledWith({

--- a/docs/superpowers/specs/2026-07-22-fixed-all-content-auto-upload-design.md
+++ b/docs/superpowers/specs/2026-07-22-fixed-all-content-auto-upload-design.md
@@ -1,0 +1,67 @@
+# Fixed All-Content Auto Upload Design
+
+## Goal
+
+Simplify the auto-upload settings screen so users can only enable or disable
+auto upload. When enabled, auto upload always synchronizes all album content.
+
+## Scope
+
+- Keep the auto-upload switch interactive.
+- Remove the complete sync-range section from `AutoUploadSettingsScreen`.
+- Remove the "From Now On" and "Custom Time" entry points and the custom date
+  picker from that screen.
+- Keep the album source as the only fixed source while auto upload is enabled.
+- Always save an enabled configuration with `timeRangeMode: 'all'` and no
+  `customTimeFrom` value, regardless of the previously persisted range.
+
+The native DTO, persistence schema, native range policies, and the separate
+album workbench configuration UI are outside this change. They retain their
+existing range-mode support.
+
+## Screen Behavior
+
+The plan card continues to show the effective range summary as "All Content"
+when auto upload is enabled and "N/A" when disabled. The detailed sync-range
+section is not rendered in either state.
+
+Configuration hydration reads only the saved enabled state needed by the
+switch. Previously saved `from_now`, `from_today`, or `custom` values do not
+affect the screen. The next successful switch-on flow normalizes the saved
+configuration to `all` before starting native auto upload.
+
+The existing permission preflight, save-before-enable ordering, rapid-toggle
+guard, error recovery, disable flow, navigation, and fixed album source remain
+unchanged.
+
+## Implementation
+
+Remove range-specific component state, conversion helpers, date-picker event
+handlers, range copy lookups, icons, modal rendering, and styles from
+`AutoUploadSettingsScreen`. Replace its enable persistence helper inputs with a
+fixed payload:
+
+```ts
+{
+  enabled: true,
+  timeRangeMode: 'all',
+  customTimeFrom: undefined,
+}
+```
+
+No shared contract or native module changes are required.
+
+## Testing
+
+Update the screen tests first and confirm they fail against the current UI.
+The tests will verify that:
+
+- no sync-range title, option, or custom picker is rendered;
+- the plan summary reports "All Content" while enabled;
+- enabling from any previously persisted range saves `all` with no custom
+  timestamp;
+- existing enable, disable, permission, concurrency, error, navigation, and
+  album-source behavior remains intact.
+
+Run the focused screen test and the mobile TypeScript type check after the
+implementation. Run the broader mobile test suite if the focused checks pass.


### PR DESCRIPTION
## Summary

- remove the entire sync time range section and the custom date/time picker from mobile auto-upload settings
- keep the Auto Upload switch and the fixed Photos and Videos source
- always persist enabled auto-upload with timeRangeMode: all and no customTimeFrom value
- preserve permission preflight, save-before-enable ordering, duplicate-tap protection, and disable/error recovery
- keep the Android capture-time filtering and foreground rescan corrections already included in this branch

## Behavior

Users can still enable or disable Auto Upload. When enabled, the plan summary shows All Content and the native configuration is normalized to the all-content range. From Now On and Custom Time are no longer available from this screen.

## Impact

The UI change affects the React Native auto-upload settings screen on both iOS and Android. Shared DTOs, native persistence schemas, queue semantics, upload serialization, the sync state machine, account/capability gates, and the separate Album Workbench range UI are unchanged.

## Validation

- AutoUploadSettingsScreen Jest suite: 13/13 passed
- complete mobile Jest suite: 55 suites, 434 tests passed
- mobile TypeScript check passed
- focused ESLint check passed
- Prettier check passed
- git diff --check passed
- Android unit tests and Debug assembly passed for the native changes earlier in this branch
- GitHub Native Builds previously passed for both iOS and Android

Fixes #148